### PR TITLE
Include image in info

### DIFF
--- a/lib/omniauth/strategies/meetup.rb
+++ b/lib/omniauth/strategies/meetup.rb
@@ -22,6 +22,7 @@ module OmniAuth
           :id => raw_info['id'],
           :name => raw_info['name'],
           :photo_url => (raw_info.key?('photo') ? raw_info['photo']['photo_link'] : nil),
+          :image => (raw_info.key?('photo') ? raw_info['photo']['photo_link'] : nil),
           :urls => { :public_profile => raw_info['link'] },
           :description => raw_info['bio'],
           :location => [raw_info['city'], raw_info['state'], raw_info['country']].reject{|v| !v || v.empty?}.join(', ')

--- a/spec/omniauth/strategies/meetup_spec.rb
+++ b/spec/omniauth/strategies/meetup_spec.rb
@@ -45,6 +45,13 @@ describe OmniAuth::Strategies::Meetup do
       subject.info[:photo_url].should == nil
     end
 
+    it 'returns the image from raw_info if available' do
+      subject.stub(:raw_info) { { 'photo' => { 'photo_link' => 'http://meetup.com/bert.jpg' } }}
+      subject.info[:image].should == 'http://meetup.com/bert.jpg'
+      subject.stub(:raw_info) {{}}
+      subject.info[:image].should == nil
+    end
+    
     it 'returns the public_profile url' do
       subject.stub(:raw_info) { { 'link' => 'http://meetup.com/bert' }}
       subject.info[:urls][:public_profile].should == 'http://meetup.com/bert'


### PR DESCRIPTION
Currently returns photo_url, but omniauth schema asks for image. Kept photo_url but added image.
