### PR TITLE
Meetup OAuth2 change

### DIFF
--- a/lib/omniauth/strategies/meetup.rb
+++ b/lib/omniauth/strategies/meetup.rb
@@ -34,7 +34,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= JSON.parse(access_token.get("/2/member/self?key=#{access_token.token}&access_token=#{access_token.token}").body)
+        @raw_info ||= JSON.parse(access_token.get('/2/member/self').body)
       end
 
     end


### PR DESCRIPTION
Meetup has made a change to their OAuth implementation. It returns
an error when using two forms of authentication.

You can refer to this url for a little history on the problem.
https://groups.google.com/forum/?fromgroups=#!topic/meetup-api/Ox1NG2mplkU
